### PR TITLE
There is a small bug in a printf function.

### DIFF
--- a/MINTmap.pl
+++ b/MINTmap.pl
@@ -413,7 +413,7 @@ sub createOutput
    $filename = "$opt{p}-$scriptversion-$tRFtypes.countsmeta.txt";
    printf ("Creating output file: %s\n", $filename);
    open $ofh, ">$filename" or die $!;
-   printf ($ofh "Total reads in -f input file\tTotal unnormalized reads in %s\tPercent\n", $tRFtypes, $tRFtypes);
+   printf ($ofh "Total reads in -f input file\tTotal unnormalized reads in %s\tPercent\n", $tRFtypes);
    printf ($ofh "%ld\t%ld\t%.2f%%\n", $stat_totalstartingreads, $total_frags_in_file, ($total_frags_in_file / $stat_totalstartingreads) * 100);
    close ($ofh);
 }


### PR DESCRIPTION
An extra $tRFtypes variable was removed from printf at line 416.